### PR TITLE
[+] add themes in some components.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,9 +5,9 @@
       "weexcomponent",
       {
         "style": false,
+        "jsTheme": true,
         "libraryName": "weex-ui",
         "libDir": "packages",
-        "themeDir": "lib/theme",
         "themeConfig": {
           "name": "default"
         }

--- a/example/_mods/set-nav.js
+++ b/example/_mods/set-nav.js
@@ -6,7 +6,7 @@
 
 const navigationBar = weex.requireModule('navigationBar');
 const navigator = weex.requireModule('navigator');
-import { Utils } from '../../index';
+import { Utils } from 'weex-ui';
 
 export function setTitle (title) {
   if (navigationBar && navigationBar.setTitle) {

--- a/example/button/index.vue
+++ b/example/button/index.vue
@@ -207,7 +207,7 @@
 </style>
 
 <script>
-  import { WxcButton, WxcCell } from '../../index';
+  import { WxcButton, WxcCell } from 'weex-ui';
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
   import { setTitle } from '../_mods/set-nav';

--- a/example/cell/index.vue
+++ b/example/cell/index.vue
@@ -116,7 +116,7 @@
 
 <script>
   const modal = weex.requireModule('modal');
-  import { WxcCell } from '../../index';
+  import { WxcCell } from 'weex-ui';
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
   import { setTitle } from '../_mods/set-nav';

--- a/example/checkbox/index.vue
+++ b/example/checkbox/index.vue
@@ -54,7 +54,7 @@
 <script>
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcCheckbox, WxcCheckboxList } from '../../index'
+  import { WxcCheckbox, WxcCheckboxList } from 'weex-ui'
   import { setTitle } from '../_mods/set-nav';
 
   export default {

--- a/example/city/index.vue
+++ b/example/city/index.vue
@@ -42,7 +42,7 @@
 <script>
   import sourceData from './data';
   import * as Util from '../../packages/wxc-city/util';
-  import { WxcCity } from '../../index';
+  import { WxcCity } from 'weex-ui';
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
 

--- a/example/countdown/index.vue
+++ b/example/countdown/index.vue
@@ -148,7 +148,7 @@
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
 
-  import { WxcCountdown } from '../../index'
+  import { WxcCountdown } from 'weex-ui'
 
   export default {
     components: { Title, Category, WxcCountdown },

--- a/example/dialog/index.vue
+++ b/example/dialog/index.vue
@@ -127,7 +127,7 @@
 
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcDialog, WxcCell } from '../../index';
+  import { WxcDialog, WxcCell } from 'weex-ui';
 
   const modal = weex.requireModule('modal');
   import { setTitle } from '../_mods/set-nav';

--- a/example/ep-slider/index.vue
+++ b/example/ep-slider/index.vue
@@ -122,7 +122,7 @@
 <script>
   const modal = weex.requireModule('modal');
 
-  import { WxcEpSlider, WxcPanItem, BindEnv } from '../../index';
+  import { WxcEpSlider, WxcPanItem, BindEnv } from 'weex-ui';
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
   import { setTitle } from '../_mods/set-nav';

--- a/example/grid-select/index.vue
+++ b/example/grid-select/index.vue
@@ -78,7 +78,7 @@
 
 <script>
 
-  import { WxcGridSelect } from '../../index';
+  import { WxcGridSelect } from 'weex-ui';
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
   import { setTitle } from '../_mods/set-nav';

--- a/example/icon/index.vue
+++ b/example/icon/index.vue
@@ -53,7 +53,7 @@
 </style>
 
 <script>
-  import { WxcIcon, Utils } from '../../index';
+  import { WxcIcon, Utils } from 'weex-ui';
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
   import { setTitle } from '../_mods/set-nav';

--- a/example/indexlist/index.vue
+++ b/example/indexlist/index.vue
@@ -21,7 +21,7 @@
 
 <script>
   const modal = weex.requireModule('modal');
-  import { WxcIndexlist } from '../../index';
+  import { WxcIndexlist } from 'weex-ui';
   import { dataList } from './data.js';
   import { setTitle } from '../_mods/set-nav';
 

--- a/example/lightbox/index.vue
+++ b/example/lightbox/index.vue
@@ -82,7 +82,7 @@
 <script>
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcLightbox } from '../../index';
+  import { WxcLightbox } from 'weex-ui';
 
   import { setTitle } from '../_mods/set-nav';
 

--- a/example/loading/index.vue
+++ b/example/loading/index.vue
@@ -74,7 +74,7 @@
 <script>
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcLoading, WxcPartLoading, WxcCell } from '../../index';
+  import { WxcLoading, WxcPartLoading, WxcCell } from 'weex-ui';
 
   import { setTitle } from '../_mods/set-nav';
 

--- a/example/lottery-rain/index.vue
+++ b/example/lottery-rain/index.vue
@@ -15,7 +15,7 @@
 </style>
 
 <script>
-  import { WxcLotteryRain } from '../../index'
+  import { WxcLotteryRain } from 'weex-ui'
   import { setTitle } from '../_mods/set-nav';
 
   export default {

--- a/example/mask/index.vue
+++ b/example/mask/index.vue
@@ -101,7 +101,7 @@
 
 </style>
 <script>
-  import { WxcMask } from '../../index';
+  import { WxcMask } from 'weex-ui';
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
 

--- a/example/minibar/index.vue
+++ b/example/minibar/index.vue
@@ -74,7 +74,7 @@
 <script>
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcMinibar } from '../../index';
+  import { WxcMinibar } from 'weex-ui';
 
   const modal = weex.requireModule('modal');
   import { setTitle } from '../_mods/set-nav';

--- a/example/minibar/index.vue
+++ b/example/minibar/index.vue
@@ -8,6 +8,9 @@
       <category title="使用案例"></category>
       <div>
         <div class="demo">
+          <wxc-minibar title="主题色"></wxc-minibar>
+        </div>
+        <div class="demo">
           <wxc-minibar title="Minibar" background-color="#F2F3F4"></wxc-minibar>
         </div>
         <div class="demo">

--- a/example/noticebar/index.vue
+++ b/example/noticebar/index.vue
@@ -85,7 +85,7 @@
   const modal = weex.requireModule('modal');
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcNoticebar } from '../../index';
+  import { WxcNoticebar } from 'weex-ui';
 
   import { setTitle } from '../_mods/set-nav';
 

--- a/example/overlay/index.vue
+++ b/example/overlay/index.vue
@@ -68,7 +68,7 @@
   const modal = weex.requireModule('modal');
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcOverlay } from '../../index';
+  import { WxcOverlay } from 'weex-ui';
   import { setTitle } from '../_mods/set-nav';
 
   export default {

--- a/example/page-calendar/index.vue
+++ b/example/page-calendar/index.vue
@@ -114,7 +114,7 @@
 <script>
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcPageCalendar } from '../../index';
+  import { WxcPageCalendar } from 'weex-ui';
 
   const modal = weex.requireModule('modal');
 

--- a/example/popover/index.vue
+++ b/example/popover/index.vue
@@ -97,7 +97,7 @@
 <script>
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcMinibar, WxcButton, WxcPopover } from '../../index';
+  import { WxcMinibar, WxcButton, WxcPopover } from 'weex-ui';
 
   const modal = weex.requireModule('modal');
   import { setTitle } from '../_mods/set-nav';

--- a/example/popup/index.vue
+++ b/example/popup/index.vue
@@ -152,7 +152,7 @@
 </style>
 
 <script>
-  import { WxcPopup } from '../../index';
+  import { WxcPopup } from 'weex-ui';
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
   import { setTitle } from '../_mods/set-nav';

--- a/example/progress/index.vue
+++ b/example/progress/index.vue
@@ -107,7 +107,7 @@
 <script>
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcProgress } from '../../index'
+  import { WxcProgress } from 'weex-ui'
   import { setTitle } from '../_mods/set-nav';
 
   export default {

--- a/example/radio/index.vue
+++ b/example/radio/index.vue
@@ -39,7 +39,7 @@
 <script>
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcRadio } from '../../index';
+  import { WxcRadio } from 'weex-ui';
   import { setTitle } from '../_mods/set-nav';
 
   export default {

--- a/example/refresher/index.vue
+++ b/example/refresher/index.vue
@@ -27,7 +27,7 @@
   import Category from '../_mods/category.vue';
   import { setTitle } from '../_mods/set-nav';
 
-  import { WxcRefresher } from '../../index';
+  import { WxcRefresher } from 'weex-ui';
 
   const modal = weex.requireModule('modal');
 

--- a/example/result/index.vue
+++ b/example/result/index.vue
@@ -25,7 +25,7 @@
 <script>
   const modal = weex.requireModule('modal');
 
-  import { WxcResult } from '../../index';
+  import { WxcResult } from 'weex-ui';
 
   import { setTitle } from '../_mods/set-nav';
 

--- a/example/rich-text/index.vue
+++ b/example/rich-text/index.vue
@@ -72,7 +72,7 @@
 <script>
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcRichText, WxcSpecialRichText } from '../../index';
+  import { WxcRichText, WxcSpecialRichText } from 'weex-ui';
   import { setTitle } from '../_mods/set-nav';
 
   export default {

--- a/example/searchbar/index.vue
+++ b/example/searchbar/index.vue
@@ -91,7 +91,7 @@
   const modal = weex.requireModule('modal');
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcSearchbar } from '../../index'
+  import { WxcSearchbar } from 'weex-ui'
   import { setTitle } from '../_mods/set-nav';
 
   export default {

--- a/example/simple-flow/index.vue
+++ b/example/simple-flow/index.vue
@@ -75,7 +75,7 @@
 <script>
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcSimpleFlow } from '../../index';
+  import { WxcSimpleFlow } from 'weex-ui';
   import { setTitle } from '../_mods/set-nav';
 
   export default {

--- a/example/slide-nav/index.vue
+++ b/example/slide-nav/index.vue
@@ -102,7 +102,7 @@
 </style>
 
 <script>
-  import { WxcSlideNav } from '../../index';
+  import { WxcSlideNav } from 'weex-ui';
   import { setTitle } from '../_mods/set-nav';
 
   let isWeb = typeof window === 'object' && weex.config.env.platform.toLowerCase() === 'web';

--- a/example/slider-bar/index.vue
+++ b/example/slider-bar/index.vue
@@ -71,7 +71,7 @@
 <script>
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcSliderBar } from '../../index';
+  import { WxcSliderBar } from 'weex-ui';
   import { setTitle } from '../_mods/set-nav';
 
   export default {

--- a/example/stepper/index.vue
+++ b/example/stepper/index.vue
@@ -67,7 +67,7 @@
 <script>
   import Title from '../_mods/title.vue';
   import Category from '../_mods/category.vue';
-  import { WxcStepper } from '../../index';
+  import { WxcStepper } from 'weex-ui';
 
   const modal = weex.requireModule('modal');
   import { setTitle } from '../_mods/set-nav';

--- a/example/tab-bar/index.vue
+++ b/example/tab-bar/index.vue
@@ -22,7 +22,7 @@
   }
 </style>
 <script>
-  import { WxcTabBar, Utils } from '../../index';
+  import { WxcTabBar, Utils } from 'weex-ui';
   import Config from './config'
   import { setTitle } from '../_mods/set-nav';
 

--- a/example/tab-page/index.vue
+++ b/example/tab-page/index.vue
@@ -60,7 +60,7 @@
 <script>
   const dom = weex.requireModule('dom');
 
-  import { WxcTabPage, WxcPanItem, Utils, BindEnv } from '../../index';
+  import { WxcTabPage, WxcPanItem, Utils, BindEnv } from 'weex-ui';
   import WxcItem from './wxc-item.vue';
 
   import Config from './config'

--- a/example/tab-page/wxc-item.vue
+++ b/example/tab-page/wxc-item.vue
@@ -142,7 +142,7 @@
 
 <script>
   const expressionBinding = weex.requireModule('expressionBinding');
-  import { WxcRichText, WxcSpecialRichText, Utils } from '../../index';
+  import { WxcRichText, WxcSpecialRichText, Utils } from 'weex-ui';
 
   export default {
     components: { WxcRichText, WxcSpecialRichText },

--- a/example/tag/advance.vue
+++ b/example/tag/advance.vue
@@ -57,7 +57,7 @@
 </style>
 
 <script>
-  import { WxcTag, WxcCell } from '../../index';
+  import { WxcTag, WxcCell } from 'weex-ui';
 
   export default {
     components: { WxcTag, WxcCell },

--- a/example/tag/image-advance.vue
+++ b/example/tag/image-advance.vue
@@ -30,7 +30,7 @@
 </style>
 
 <script>
-  import { WxcTag, WxcCell } from '../../index';
+  import { WxcTag, WxcCell } from 'weex-ui';
 
   export default {
     components: { WxcTag, WxcCell },

--- a/example/tag/regular.vue
+++ b/example/tag/regular.vue
@@ -21,7 +21,7 @@
 </style>
 
 <script>
-  import { WxcTag } from '../../index';
+  import { WxcTag } from 'weex-ui';
   import Data from './data'
   export default {
     components: { WxcTag },

--- a/example/tag/special-advance.vue
+++ b/example/tag/special-advance.vue
@@ -60,7 +60,7 @@
 </style>
 
 <script>
-  import { WxcTag, WxcCell } from '../../index';
+  import { WxcTag, WxcCell } from 'weex-ui';
 
   export default {
     components: { WxcTag, WxcCell },

--- a/lib/theme/blue/index.js
+++ b/lib/theme/blue/index.js
@@ -1,0 +1,7 @@
+export default {
+  primaryColor: '#198DED',
+  lightColor: '#269CFC',
+  highlightColor: '#0A73C9',
+  weakColor: '#E6F8FF',
+  disabledColor: '#BDE2FB'
+}

--- a/lib/theme/blue/index.js
+++ b/lib/theme/blue/index.js
@@ -3,5 +3,9 @@ export default {
   lightColor: '#269CFC',
   highlightColor: '#0A73C9',
   weakColor: '#E6F8FF',
-  disabledColor: '#BDE2FB'
+  disabledColor: '#BDE2FB',
+  grayColor: '#F2F3F4',
+  fontColorLight: '#FFFFFF',
+  fontColorDark: '#3D3D3D',
+  fontColorGray: '#F2F3F4'
 }

--- a/lib/theme/default/index.js
+++ b/lib/theme/default/index.js
@@ -1,4 +1,7 @@
 export default {
-  mainColor: '#ffffff',
-  tintColor: '#E5E5E5'
+  primaryColor: '#FFAF00',
+  lightColor: '#FFCD45',
+  highlightColor: '#C99014',
+  weakColor: '#FFF9EE',
+  disabledColor: '#FFEABE'
 }

--- a/lib/theme/default/index.js
+++ b/lib/theme/default/index.js
@@ -3,5 +3,9 @@ export default {
   lightColor: '#FFCD45',
   highlightColor: '#C99014',
   weakColor: '#FFF9EE',
-  disabledColor: '#FFEABE'
+  disabledColor: '#FFEABE',
+  grayColor: '#F2F3F4',
+  fontColorLight: '#FFFFFF',
+  fontColorDark: '#3D3D3D',
+  fontColorGray: '#F2F3F4'
 }

--- a/lib/theme/default/searchbar.js
+++ b/lib/theme/default/searchbar.js
@@ -1,4 +1,0 @@
-export default {
-  backgroundColor: '#ffffff',
-  inputBackground: '#E5E5E5'
-}

--- a/lib/theme/green/index.js
+++ b/lib/theme/green/index.js
@@ -3,5 +3,9 @@ export default {
   lightColor: '#58CC82',
   highlightColor: '#2AA155',
   weakColor: '#E6FFEC',
-  disabledColor: '#C4F2D2'
+  disabledColor: '#C4F2D2',
+  grayColor: '#F2F3F4',
+  fontColorLight: '#FFFFFF',
+  fontColorDark: '#3D3D3D',
+  fontColorGray: '#F2F3F4'
 }

--- a/lib/theme/green/index.js
+++ b/lib/theme/green/index.js
@@ -1,0 +1,7 @@
+export default {
+  primaryColor: '#3BC06B',
+  lightColor: '#58CC82',
+  highlightColor: '#2AA155',
+  weakColor: '#E6FFEC',
+  disabledColor: '#C4F2D2'
+}

--- a/lib/theme/red/index.js
+++ b/lib/theme/red/index.js
@@ -3,5 +3,9 @@ export default {
   lightColor: '#DB574B',
   highlightColor: '#B83125',
   weakColor: '#FFE9E9',
-  disabledColor: '#F8C3C3'
+  disabledColor: '#F8C3C3',
+  grayColor: '#F2F3F4',
+  fontColorLight: '#FFFFFF',
+  fontColorDark: '#3D3D3D',
+  fontColorGray: '#F2F3F4'
 }

--- a/lib/theme/red/index.js
+++ b/lib/theme/red/index.js
@@ -1,0 +1,7 @@
+export default {
+  primaryColor: '#D33A2A',
+  lightColor: '#DB574B',
+  highlightColor: '#B83125',
+  weakColor: '#FFE9E9',
+  disabledColor: '#F8C3C3'
+}

--- a/lib/theme/yellow/index.js
+++ b/lib/theme/yellow/index.js
@@ -1,4 +1,0 @@
-export default {
-  mainColor: '#ffc900',
-  tintColor: '#fff6d6'
-}

--- a/lib/theme/yellow/searchbar.js
+++ b/lib/theme/yellow/searchbar.js
@@ -1,4 +1,0 @@
-export default {
-  backgroundColor: '#ffc900',
-  inputBackground: '#fff6d6'
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1273,9 +1273,9 @@
       }
     },
     "babel-plugin-weexcomponent": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-weexcomponent/-/babel-plugin-weexcomponent-0.0.1.tgz",
-      "integrity": "sha512-KmSg8FQJ9IwBb3SGTz1oN1eIMACxOAh0g1MPOuQ1pBCAGxqcXTXSqaRK0Z16xgDExrofJUznKZ5lcP9/UIzMdw==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-weexcomponent/-/babel-plugin-weexcomponent-0.0.2.tgz",
+      "integrity": "sha512-9qLgwid8KIB1WHUA+MxpItJPxhbnf9s5si8xB4lyE8Jy5ZhBah9DAdf9yCftJT6SLj5m/0q3ngAzcrXtb318vQ==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "7.0.0-beta.35"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "webpack --progress",
     "watch": "webpack --progress --watch",
-    "serve": "anywhere -d build/example/ -p 8888",
+    "serve": "anywhere -d build/example/ -p 3333",
     "start": "npm run build && (npm run serve & npm run watch)"
   },
   "keywords": [
@@ -44,7 +44,7 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "~8.0.1",
     "babel-loader": "^7.1.2",
-    "babel-plugin-weexcomponent": "^0.0.1",
+    "babel-plugin-weexcomponent": "^0.0.2",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "babel-runtime": "^6.26.0",

--- a/packages/wxc-checkbox/index.vue
+++ b/packages/wxc-checkbox/index.vue
@@ -30,6 +30,7 @@
 <script>
   import WxcCell from '../wxc-cell';
   import { CHECKED, UNCHECKED, CHECKED_DISABLED, UNCHECKED_DISABLED } from './type'
+  import STYLE from 'weex-ui/lib/theme/default/index.js';
 
   export default {
     components: { WxcCell },
@@ -64,8 +65,8 @@
       }
     },
     data: () => ({
+      STYLE: Object.assign({}, STYLE),
       icon: [CHECKED, UNCHECKED, CHECKED_DISABLED, UNCHECKED_DISABLED],
-      color: '#3D3D3D',
       innerChecked: false
     }),
     computed: {
@@ -84,8 +85,8 @@
       },
       textColor () {
         const { innerChecked, disabled, config } = this;
-        const checkedColor = config.checkedColor ? config.checkedColor : '#EE9900';
-        return innerChecked && !disabled ? checkedColor : '#3D3D3D';
+        const checkedColor = config.checkedColor ? config.checkedColor : this.STYLE.primaryColor;
+        return innerChecked && !disabled ? checkedColor : this.STYLE.fontColorDark;
       }
     },
     watch: {

--- a/packages/wxc-minibar/index.vue
+++ b/packages/wxc-minibar/index.vue
@@ -38,7 +38,6 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    background-color: #009ff0;
   }
 
   .left {
@@ -77,11 +76,13 @@
 
 <script>
   const Navigator = weex.requireModule('navigator');
+  import STYLE from 'weex-ui/lib/theme/default/index.js';
+
   export default {
     props: {
       backgroundColor: {
         type: String,
-        default: '#FFC900'
+        default: STYLE.primaryColor
       },
       leftButton: {
         type: String,
@@ -89,7 +90,7 @@
       },
       textColor: {
         type: String,
-        default: '#3D3D3D'
+        default: STYLE.fontColorDark
       },
       rightButton: {
         type: String,

--- a/packages/wxc-radio/item.vue
+++ b/packages/wxc-radio/item.vue
@@ -31,6 +31,7 @@
 <script>
   import WxcCell from '../wxc-cell';
   import { CHECKED, DISABLED } from './type.js'
+  import STYLE from 'weex-ui/lib/theme/default/index.js';
 
   export default {
     components: { WxcCell },
@@ -61,6 +62,7 @@
       }
     },
     data: () => ({
+      STYLE: Object.assign({}, STYLE),
       icon: [CHECKED, DISABLED]
     }),
     computed: {
@@ -73,13 +75,13 @@
       },
       backgroundColor () {
         const { disabled } = this;
-        return disabled ? '#F2F3F4' : '#FFFFFF';
+        return disabled ? STYLE.grayColor : '#FFFFFF';
       },
       color () {
-        const { disabled, checked, config } = this;
-        let checkedColor = '#EE9900';
+        const { disabled, checked, config, STYLE } = this;
+        let checkedColor = STYLE.primaryColor;
         config.checkedColor && (checkedColor = config.checkedColor);
-        return checked && !disabled ? checkedColor : '#3D3D3D';
+        return checked && !disabled ? checkedColor : STYLE.fontColorDark;
       }
     },
     methods: {

--- a/packages/wxc-searchbar/index.vue
+++ b/packages/wxc-searchbar/index.vue
@@ -227,7 +227,7 @@
       }
     },
     data: () => ({
-      STYLE: {},
+      STYLE: Object.assign({}, STYLE),
       inputIcon: INPUT_ICON,
       closeIcon: CLOSE_ICON,
       arrowIcon: ARROW_ICON,
@@ -241,7 +241,6 @@
         this.showCancel = false;
         this.showClose = false;
       }
-      this.STYLE = STYLE
     },
     methods: {
       onBlur () {

--- a/packages/wxc-searchbar/index.vue
+++ b/packages/wxc-searchbar/index.vue
@@ -5,7 +5,7 @@
 <template>
   <div>
     <div class="wxc-search-bar"
-         :style="Object.assign({backgroundColor: STYLE.backgroundColor}, barStyle)"
+         :style="Object.assign({backgroundColor: STYLE.primaryColor}, barStyle)"
          v-if="mod==='default'">
       <input @blur="onBlur"
              @focus="onFocus"
@@ -17,7 +17,7 @@
              ref="search-input"
              :type="inputType"
              :placeholder="placeholder"
-             :style="{ backgroundColor: STYLE.inputBackground, width: needShowCancel ? '624px' : '710px' }"
+             :style="{ backgroundColor: STYLE.weakColor, width: needShowCancel ? '624px' : '710px' }"
              class="search-bar-input"/>
       <div v-if="disabled"
            @click="inputDisabledClicked"
@@ -31,12 +31,12 @@
              @click="closeClicked"
              :src="closeIcon"></image>
       <text class="search-bar-button"
-            :style="{backgroundColor: STYLE.backgroundColor}"
+            :style="{backgroundColor: STYLE.primaryColor}"
             v-if="needShowCancel"
             @click="cancelClicked">{{cancelLabel}}</text>
     </div>
     <div class="wxc-search-bar"
-         :style="Object.assign({backgroundColor: STYLE.backgroundColor}, barStyle)"
+         :style="Object.assign({backgroundColor: STYLE.primaryColor}, barStyle)"
          v-if="mod==='hasDep'">
       <input @blur="onBlur"
              @focus="onFocus"
@@ -47,7 +47,7 @@
              :value="value"
              :type="inputType"
              :placeholder="placeholder"
-             :style="{ backgroundColor: STYLE.inputBackground }"
+             :style="{ backgroundColor: STYLE.weakColor }"
              class="search-bar-input input-has-dep"/>
       <div v-if="disabled"
            @click="inputDisabledClicked"
@@ -176,7 +176,7 @@
 
 <script>
   import { INPUT_ICON, ARROW_ICON, CLOSE_ICON } from './type';
-  import STYLE from 'weex-ui/lib/theme/default/searchbar.js';
+  import STYLE from 'weex-ui/lib/theme/default/index.js';
 
   export default {
     props: {

--- a/packages/wxc-slide-nav/index.vue
+++ b/packages/wxc-slide-nav/index.vue
@@ -16,8 +16,6 @@
 </style>
 
 <script>
-  import STYLE from 'weex-ui/lib/theme/default/index.js';
-
   const DOM = weex.requireModule('dom');
   const Animation = weex.requireModule('animation');
   const OFFSET_ACCURACY = 10;

--- a/packages/wxc-slide-nav/index.vue
+++ b/packages/wxc-slide-nav/index.vue
@@ -16,6 +16,8 @@
 </style>
 
 <script>
+  import STYLE from 'weex-ui/lib/theme/default/index.js';
+
   const DOM = weex.requireModule('dom');
   const Animation = weex.requireModule('animation');
   const OFFSET_ACCURACY = 10;

--- a/packages/wxc-slider-bar/index.vue
+++ b/packages/wxc-slider-bar/index.vue
@@ -49,6 +49,7 @@
   import Utils from '../utils';
   import BindEnv from '../utils/bind-env';
   import Binding from 'weex-bindingx/lib/index.weex.js';
+  import STYLE from 'weex-ui/lib/theme/default/index.js';
 
   const animation = weex.requireModule('animation');
   const dom = weex.requireModule('dom');
@@ -117,7 +118,7 @@
       },
       validColor: {
         type: String,
-        default: '#EE9900'
+        default: STYLE.primaryColor
       },
       disabledColor: {
         type: String,


### PR DESCRIPTION
These commits make these changes:

- Modified theme directory structure

- Less configuration: use babel-plugin-weexcomponent ( v0.0.2 )

- Add themes in these components:  
  - `wxc-searchbar`
  - `wxc-slider-bar`
  - `wxc-minibar`
  - `wxc-checkbox`
  - `wxc-radio`

- Optimize the packaged size of example pages.
