### PR TITLE
[!] bugfix when with only two sliders

### DIFF
--- a/packages/wxc-ep-slider/index.vue
+++ b/packages/wxc-ep-slider/index.vue
@@ -229,7 +229,7 @@
         let currentCardScale = 1;
         let rightCardScale = this.cardS.scale;
         let leftCardScale = this.cardS.scale;
-        const duration = (selectIndex === 0 && originIndex === this.cardLength - 1) ? 0.00001 : 300;
+        const duration = (selectIndex === 0 && originIndex === this.cardLength - 1 && this.cardLength !== 2) ? 0.00001 : 300;
         this.$emit('wxcEpSliderCurrentIndexSelected', { currentIndex: selectIndex });
         if (originIndex < selectIndex) {
           currentCardScale = this.cardS.scale;


### PR DESCRIPTION
The duration should be 300ms but not 0.00001 when only two sliders.