### PR TITLE
[!]fix the bug that 'default' return an undefined value

### DIFF
--- a/packages/wxc-searchbar/index.vue
+++ b/packages/wxc-searchbar/index.vue
@@ -220,7 +220,7 @@
       },
       barStyle: {
         type: Object,
-        default: () => {}
+        default: () => ({})
       },
       defaultValue: {
         type: String,


### PR DESCRIPTION
function `()=>{} ` return undefined, i guess the code owner means `()=>({})`, return an Object , or `this.barStyle.xxx` will throw an error