### PR TITLE
可以解决当一个页面展示多个grid-select会提示:key存在重复

### DIFF
--- a/packages/wxc-grid-select/index.vue
+++ b/packages/wxc-grid-select/index.vue
@@ -14,7 +14,7 @@
     <option
       v-for="(item, index) in cHackList"
       v-bind="Object.assign({}, customStyles, item)"
-      :key="index"
+      :key="id + index"
       :style="{opacity: 0, marginTop: dList.length >= cols ? lineSpacing : null}"></option>
   </div>
 </template>
@@ -25,6 +25,11 @@
   export default {
     components: { Option },
     props: {
+      // 标识, 当界面展示多个grid, 防止v-for :key重复
+      id: {
+        type: String,
+        default: 'one'
+      },
       // 列数
       cols: {
         type: Number,


### PR DESCRIPTION
解决方法可以通过传一个自定义的id(值), 使用 :key="id + index", 方法避免这个问题

第一次提交pr哈~ 可能写的不是很好