### PR TITLE
wxc-rich-text-text 组件支持传入更多样式

### DIFF
--- a/packages/wxc-rich-text/wxc-rich-text-text.vue
+++ b/packages/wxc-rich-text/wxc-rich-text-text.vue
@@ -58,19 +58,12 @@
     },
     computed: {
       themeStyle () {
-        let style = {};
-        const textStyle = this.textStyle;
-        if (textStyle && textStyle.fontSize) {
+        let style = { ...this.textStyle };
+        if (style && (style.fontSize || style['font-size'])) {
           style = {
             ...style,
-            fontSize: `${textStyle.fontSize}px`,
-            height: `${textStyle.fontSize * 1.2}px`
-          }
-        }
-        if (textStyle && textStyle.color) {
-          style = {
-            ...style,
-            color: textStyle.color
+            fontSize: `${style.fontSize || style['font-size']}px`,
+            height: `${(style.fontSize || style['font-size']) * 1.2}px`
           }
         }
         return style;


### PR DESCRIPTION
目前  wxc-rich-text-text 只支持处理传入的 style 中的 fontSize 和 color 这两个 CSS 属性。我遇到了需求需要支持更多的属性，比如 text-decoration 等，所以做了一下扩展。