### PR TITLE
 fix wxc-icon docs (large => big)

### DIFF
--- a/packages/wxc-icon/README.md
+++ b/packages/wxc-icon/README.md
@@ -32,7 +32,7 @@ Also you can copy the `name` from [demo](https://h5.m.taobao.com/trip/wx-detecti
 | Prop | Type | Required | Default | Description |
 | ---- |:----:|:---:|:-------:| :----------:|
 | **`name`** | `string` | `Y` | `-` | icon name (*1)|
-| **`size`** | `String` | `N` | `small` | icon size `xs`/`small`/`medium`/`large`|
+| **`size`** | `String` | `N` | `small` | icon size `xs`/`small`/`medium`/`big`|
 | **`icon-style`** | `Object` | `N` | `{}` |style override (*2)|
 
 - *1：icon name list：`['less', 'more_unfold', 'back', 'more', 'add', 'subtract', 'close', 'cry', 'search', 'delete', 'help', 'refresh', 'success', 'warning', 'wrong', 'clock', 'scanning', 'filter', 'map', 'play']`

--- a/packages/wxc-icon/README_cn.md
+++ b/packages/wxc-icon/README_cn.md
@@ -31,7 +31,7 @@
 | Prop | Type | Required | Default | Description |
 | ---- |:----:|:---:|:-------:| :----------:|
 | **`name`** | `string` | `Y` | `-` | icon 的名称 (注1)|
-| **`size`** | `String` | `N` | `small` | icon的尺寸 `xs`/`small`/`medium`/`large`|
+| **`size`** | `String` | `N` | `small` | icon的尺寸 `xs`/`small`/`medium`/`big`|
 | **`icon-style`** | `Object` | `N` | `{}` |样式覆盖 (注2)|
 
 - 注1：icon的名称详细如下：`['less', 'more_unfold', 'back', 'more', 'add', 'subtract', 'close', 'cry', 'search', 'delete', 'help', 'refresh', 'success', 'warning', 'wrong', 'clock', 'scanning', 'filter', 'map', 'play']`


### PR DESCRIPTION
https://github.com/alibaba/weex-ui/blob/c4b5c68534997423c1e2de31e512ff2e3347eb5a/packages/wxc-icon/index.vue#L57

It should be `big` instead of `large` .