### PR TITLE
[!] 修复 iPhoneXR 适配，模拟器10.2版iPhoneXR ios12.2 高度1624

### DIFF
--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -110,7 +110,7 @@ const Utils = {
         && ((parseInt(window.screen.width, 10) === 375) && (parseInt(window.screen.height, 10) === 812)
         || (parseInt(window.screen.width, 10) === 414) && (parseInt(window.screen.height, 10) === 896));
       }
-      return Utils.env.isIOS() && (deviceHeight === 2436 || deviceHeight === 2688 || deviceHeight == 1792);
+      return Utils.env.isIOS() && (deviceHeight === 2436 || deviceHeight === 2688 || deviceHeight === 1792 || deviceHeight === 1624);
     },
     isAndroid () {
       const { platform } = weex.config.env;


### PR DESCRIPTION
手上没有 iPhone XR 机器，但是模拟器 deviceHeight 是 1624 而不是 1792，谷歌了一下，也有其他人遇到这种分辨率，而且 1624 这个分辨率在其他非刘海屏机器上不存在，所以把这个也加到 isIPhoneX 的判断中了。
另外之前的代码对比 1792 分辨率的时候应该是不小心用了 == ，跟其他校验项一样写成 === 了。同一行代码就没有单独提 PR