### PR TITLE
[!] 修复 wxc-loading 组件文档示例代码无法直接运行的问题

### DIFF
--- a/packages/wxc-loading/README_cn.md
+++ b/packages/wxc-loading/README_cn.md
@@ -14,17 +14,20 @@
 
 ```vue
 <template>
-   <wxc-loading :show="isShow" type="trip"></wxc-loading>
-   <wxc-part-loading :show="isShow"></wxc-part-loading>
+    <div>
+        <wxc-loading :show="isShow" type="trip"></wxc-loading>
+        <wxc-part-loading :show="isShow"></wxc-part-loading>
+    </div>
 </template>
 <script>
     import { WxcLoading, WxcPartLoading } from 'weex-ui';
-      components: { WxcLoading, WxcPartLoading },
-      data () {
-        return {
-          isShow: true
-        };
-      }
+    export default {
+        components: { WxcLoading, WxcPartLoading },
+        data () {
+            return {
+                isShow: true
+            };
+        }
     };
 </script>
 ```


### PR DESCRIPTION
在用 wxc-loading 组件，发现示例代码里面 template 标签有两个根组件，script 标签里有语法错误，于是都修复了。