### PR TITLE
[!] wxc-special-rich-text 暴露单击事件，添加tagDivStyle属性可以修改tag-div样式

### DIFF
--- a/packages/wxc-progress/README.md
+++ b/packages/wxc-progress/README.md
@@ -87,4 +87,4 @@ More details can be found in [here](https://github.com/alibaba/weex-ui/blob/mast
 | bar-color | `String` |`N`| `#FFC900` | progress bar color |
 | bar-width | `Number` |`N`| `600` | progress bar width |
 | bar-radius | `number` |`n`| `0` | progress bar radius |
-| bgd-color | `String` |`N`| `#f2f3f4` | overall background color |
+| background-color | `String` |`N`| `#f2f3f4` | overall background color |

--- a/packages/wxc-progress/README.md
+++ b/packages/wxc-progress/README.md
@@ -84,5 +84,7 @@ More details can be found in [here](https://github.com/alibaba/weex-ui/blob/mast
 |-------------|------------|--------|-----|-----|
 | value | `Number` |`Y`| `0` | percent `(0-100)` |
 | bar-height | `Number` |`N`| `8` | progress bar height |
+| bar-color | `String` |`N`| `#FFC900` | progress bar color |
 | bar-width | `Number` |`N`| `600` | progress bar width |
 | bar-radius | `number` |`n`| `0` | progress bar radius |
+| bgd-color | `String` |`N`| `#f2f3f4` | overall background color |

--- a/packages/wxc-progress/README_cn.md
+++ b/packages/wxc-progress/README_cn.md
@@ -87,3 +87,4 @@
 | bar-width | `Number` |`N`| `600` | 长度 |
 | bar-color | `String` |`N`| `#FFC900` | 颜色 |
 | bar-radius | `Number` |`N`| `0` | 圆角 |
+| bgd-color | `String` |`N`| `#f2f3f4` | 整体背景色 |

--- a/packages/wxc-progress/README_cn.md
+++ b/packages/wxc-progress/README_cn.md
@@ -87,4 +87,4 @@
 | bar-width | `Number` |`N`| `600` | 长度 |
 | bar-color | `String` |`N`| `#FFC900` | 颜色 |
 | bar-radius | `Number` |`N`| `0` | 圆角 |
-| bgd-color | `String` |`N`| `#f2f3f4` | 整体背景色 |
+| background-color | `String` |`N`| `#f2f3f4` | 整体背景色 |

--- a/packages/wxc-progress/index.vue
+++ b/packages/wxc-progress/index.vue
@@ -43,15 +43,20 @@
       value: {
         type: Number,
         default: 0
+      },
+      bgdColor: {
+        type: String,
+        default: '#f2f3f4'
       }
     },
     computed: {
       runWayStyle () {
-        const { barWidth, barHeight, barRadius } = this;
+        const { barWidth, barHeight, barRadius, bgdColor } = this;
         return {
           width: barWidth + 'px',
           height: barHeight + 'px',
-          borderRadius: barRadius + 'px'
+          borderRadius: barRadius + 'px',
+          backgroundColor: bgdColor
         }
       },
       progressStyle () {

--- a/packages/wxc-progress/index.vue
+++ b/packages/wxc-progress/index.vue
@@ -44,19 +44,19 @@
         type: Number,
         default: 0
       },
-      bgdColor: {
+      backgroundColor: {
         type: String,
         default: '#f2f3f4'
       }
     },
     computed: {
       runWayStyle () {
-        const { barWidth, barHeight, barRadius, bgdColor } = this;
+        const { barWidth, barHeight, barRadius, backgroundColor } = this;
         return {
           width: barWidth + 'px',
           height: barHeight + 'px',
           borderRadius: barRadius + 'px',
-          backgroundColor: bgdColor
+          backgroundColor
         }
       },
       progressStyle () {

--- a/packages/wxc-rich-text/README.md
+++ b/packages/wxc-rich-text/README.md
@@ -19,7 +19,7 @@
     <wxc-rich-text :config-list='configList'
                    @wxcRichTextLinkClick='wxcRichTextLinkClick'></wxc-rich-text>
      <div class='special-rich'>
-       <wxc-special-rich-text :config-list='specialConfigList'></wxc-special-rich-text>
+       <wxc-special-rich-text @wxcSpecialRichTextClick="wxcSpecialRichTextClick"  :config-list='specialConfigList'></wxc-special-rich-text>
      </div>
   </div>
   
@@ -76,6 +76,9 @@
             borderColor: '#FFC900',
             backgroundColor: '#FFC900',
             borderRadius: 14,
+          },
+          tagDivStyle: {
+            left: '50px'
           }
         },
         {
@@ -89,7 +92,8 @@
       ],
     }),
     methods: {
-      wxcRichTextLinkClick () {}
+      wxcRichTextLinkClick () {},
+      wxcSpecialRichTextClick () {}
     }
   };
 </script>
@@ -110,6 +114,7 @@ More details can be found in [here](https://github.com/alibaba/weex-ui/blob/mast
 
 ```
 @wxcRichTextLinkClick='wxcRichTextLinkClick'
+@wxcSpecialRichTextClick="wxcSpecialRichTextClick"
 ```
 
 

--- a/packages/wxc-rich-text/README_cn.md
+++ b/packages/wxc-rich-text/README_cn.md
@@ -19,7 +19,7 @@
     <wxc-rich-text :config-list="configList"
                    @wxcRichTextLinkClick="wxcRichTextLinkClick"></wxc-rich-text>
      <div class="special-rich">
-       <wxc-special-rich-text :config-list="specialConfigList"></wxc-special-rich-text>
+       <wxc-special-rich-text @wxcSpecialRichTextClick="wxcSpecialRichTextClick" :config-list="specialConfigList"></wxc-special-rich-text>
      </div>
   </div>
   
@@ -76,6 +76,9 @@
             borderColor: '#FFC900',
             backgroundColor: '#FFC900',
             borderRadius: 14,
+          },
+          tagDivStyle: {
+            left: '50px'
           }
         },
         {
@@ -89,7 +92,8 @@
       ],
     }),
     methods: {
-      wxcRichTextLinkClick () {}
+      wxcRichTextLinkClick () {},
+      wxcSpecialRichTextClick () {}
     }
   };
 </script>
@@ -110,6 +114,7 @@
 
 ```
 @wxcRichTextLinkClick="wxcRichTextLinkClick"
+@wxcSpecialRichTextClick="wxcSpecialRichTextClick"
 ```
 
 

--- a/packages/wxc-special-rich-text/index.vue
+++ b/packages/wxc-special-rich-text/index.vue
@@ -3,9 +3,9 @@
 <!-- just hack for babel-plugin-component !!!-->
 
 <template>
-  <div class="wxc-special-rich-text">
+  <div class="wxc-special-rich-text" @click="$emit('wxcSpecialRichTextClick')">
     <div class="tag-div"
-         :style="{top:top+'px'}">
+         :style="Object.assign({top:top+'px'}, newList[0].tagDivStyle)">
       <image class="wxc-image"
              v-if="newList[0] && newList[0].type === 'icon' && newList[0].src"
              :src="newList[0].src"


### PR DESCRIPTION
目前做checkbox(图片)+文字换行，该组件单击事件没有暴露，暴露了单击事件。tag-div样式也不能修改，不满足现在的需求，对该组件添加了扩展。
可以使用@wxcSpecialRichTextClick触发单击事件
```js
<wxc-special-rich-text @wxcSpecialRichTextClick="wxcRichTextLinkClick" class="special-rich"
      :config-list="test"></wxc-special-rich-text>
```
数组[0]可以添加tagDivStyle修改tag-div样式。
```js
[
        {
          type: "tag",
          value: "我已认真阅读并同意",
          theme: "none",
          style: {
            fontSize: 24,
            color: "#3D3D3D",
            // borderColor: "white"
          },
          tagDivStyle: {
            left: '50px'
          }
        },
]
```