### PR TITLE
去除button点击高亮

### DIFF
--- a/packages/wxc-button/index.vue
+++ b/packages/wxc-button/index.vue
@@ -81,10 +81,6 @@
     opacity: 1;
   }
 
-  .wxc-btn:active {
-    opacity: .8;
-  }
-
   .btn-text {
     text-overflow: ellipsis;
     lines: 1;


### PR DESCRIPTION
https://github.com/alibaba/weex-ui/pull/417
bug来自此次提交，按钮disabled状态依旧会触发。
可以:class="['wxc-btn', disabled?'':'wxc-btn-normal']"
样式wxc-btn:active改为wxc-btn-norma:active解决，但又会出现新的问题。
比如按钮是白色的active设置为opacity: .8将无意义，建议去除，或者在style.js里面设置active的样式。