### PR TITLE
解决在其他页面使用的dialog弹窗，但是一直出现在tabbar的第一个div问题。

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## 0.6.13
+- [!] fixed[wxc-overlay](https://alibaba.github.io/weex-ui/#/cn/packages/wxc-dialog/)problem on[wxc-tab-bar](https://alibaba.github.io/weex-ui/#/cn/packages/wxc-tab-bar/)
 - [+] add wxc-swipe-action
 - [!] [!] Fix [wxc-button](https://alibaba.github.io/weex-ui/#/cn/packages/wxc-button/) displaying style problem, add isHighlight attribute to control whether button is highlighted or not.
 

--- a/CHANGELOG_cn.md
+++ b/CHANGELOG_cn.md
@@ -1,6 +1,7 @@
 # 升级日志
 
 ## 0.6.13
+- [!] 修复[wxc-overlay](https://alibaba.github.io/weex-ui/#/cn/packages/wxc-dialog/)在[wxc-tab-bar](https://alibaba.github.io/weex-ui/#/cn/packages/wxc-tab-bar/)上使用问题
 - [+] 添加wxc-swipe-action侧滑组件
 - [!] 修复[wxc-button](https://alibaba.github.io/weex-ui/#/cn/packages/wxc-button/) 设置display样式问题，添加isHighlight属性控制button是否高亮显示
 

--- a/packages/wxc-dialog/README.md
+++ b/packages/wxc-dialog/README.md
@@ -74,6 +74,7 @@ More details can be found in [here](https://github.com/alibaba/weex-ui/blob/mast
 |-------------|------------|--------|-----|-----|
 | title | `String` | `Y` | `-` | title (only transparent) |
 | content | `String` | `N` | `-`| content |
+| left | `Number` |`N`| `0` | move left distance  |
 | top | `Number` | `N` |`400` |  distance from the top of the screen |
 | single | `Boolean` | `N` |`false` |  whether is single button |
 | confirm-text | `String` | `N` |`确定` |  text of the primary button |

--- a/packages/wxc-dialog/README_cn.md
+++ b/packages/wxc-dialog/README_cn.md
@@ -73,6 +73,7 @@
 | Prop | Type | Required | Default | Description |
 |-------------|------------|--------|-----|-----|
 | title | `String` | `Y` | `-` | 标题 |
+| left | `Number` |`N`| `0` | 向左移动距离  |
 | content | `String` | `N` | `-`| 内容说明描述 |
 | top | `Number` | `N` |`400` |  弹层距离顶部的高度 |
 | single | `Boolean` | `N` |`false` |  是否只有一个按钮（显示确认） |

--- a/packages/wxc-dialog/index.vue
+++ b/packages/wxc-dialog/index.vue
@@ -5,7 +5,7 @@
 <template>
   <div class="container">
     <wxc-overlay :left='left' v-if="show" :show="true" :hasAnimation="false"></wxc-overlay>
-    <div class="dialog-box" v-if="show" :style="{top:top+'px', left: (left + 96) + 'px'}">
+    <div class="dialog-box" v-if="show" :style="{top:top+'px', left: ((isWeb ? left : 0) + 96) + 'px'}">
       <div class="dialog-content">
         <slot name="title">
           <text class="content-title">{{title}}</text>
@@ -118,6 +118,7 @@
 <script>
   import WxcOverlay from '../wxc-overlay'
   import { CHECKED, UN_CHECKED } from './type';
+  import Utils from '../utils';
 
   export default {
     components: { WxcOverlay },
@@ -177,7 +178,8 @@
     },
     data: () => ({
       noPromptIcon: UN_CHECKED,
-      pageHeight: 1334
+      pageHeight: 1334,
+      isWeb: Utils.env.isWeb()
     }),
     created () {
       const { env: { deviceHeight, deviceWidth } } = weex.config;

--- a/packages/wxc-dialog/index.vue
+++ b/packages/wxc-dialog/index.vue
@@ -4,8 +4,8 @@
 
 <template>
   <div class="container">
-    <wxc-overlay v-if="show" :show="true" :hasAnimation="false"></wxc-overlay>
-    <div class="dialog-box" v-if="show" :style="{top:top+'px'}">
+    <wxc-overlay :left='left' v-if="show" :show="true" :hasAnimation="false"></wxc-overlay>
+    <div class="dialog-box" v-if="show" :style="{top:top+'px', left: (left + 96) + 'px'}">
       <div class="dialog-content">
         <slot name="title">
           <text class="content-title">{{title}}</text>
@@ -169,6 +169,10 @@
       isChecked: {
         type: Boolean,
         default: false
+      },
+      left: {
+        type: Number,
+        default: 0
       }
     },
     data: () => ({

--- a/packages/wxc-overlay/README.md
+++ b/packages/wxc-overlay/README.md
@@ -50,6 +50,7 @@ More details can be found in [here](https://github.com/alibaba/weex-ui/blob/mast
 |-------------|------------|--------|-----|
 | show | `Boolean` |`Y`| `false` | whether to show  |
 | opacity | `Number` |`N`| `0.6` | opacity `0-1` |
+| left | `Number` |`N`| `0` | move left distance  |
 | has-animation | `Boolean` |`N`| `true` | whether to animate |
 | can-auto-close | `Boolean` |`N`| `true` | whether to can auto close  |
 | duration | `Number` | `300` |`N`| animation duration time |

--- a/packages/wxc-overlay/README_cn.md
+++ b/packages/wxc-overlay/README_cn.md
@@ -48,6 +48,7 @@
 | Prop | Type | Required | Default | Description |
 |-------------|------------|--------|-----|
 | show | `Boolean` |`Y`| `false` | 是否开启  |
+| left | `Number` |`N`| `0` | 向左移动距离  |
 | opacity | `Number` |`N`| `0.6` | 蒙层opacity度数0-1 |
 | has-animation | `Boolean` |`N`| `true` | 是否开启蒙层出现动画  |
 | can-auto-close | `Boolean` |`N`| `true` | 是否可以点击自动关闭  |

--- a/packages/wxc-overlay/index.vue
+++ b/packages/wxc-overlay/index.vue
@@ -9,7 +9,7 @@
          v-if="show"
          :hack="shouldShow"
          @click="overlayClicked"
-         :style="overlayStyle">
+         :style="Object.assign({left: left + 'px'} ,overlayStyle)">
     </div>
   </div>
 </template>
@@ -18,7 +18,6 @@
   .wxc-overlay {
     width: 750px;
     position: fixed;
-    left: 0;
     top: 0;
     bottom: 0;
     right: 0;
@@ -32,6 +31,10 @@
       show: {
         type: Boolean,
         default: true
+      },
+      left: {
+        default: Number,
+        default: 0
       },
       hasAnimation: {
         type: Boolean,

--- a/packages/wxc-overlay/index.vue
+++ b/packages/wxc-overlay/index.vue
@@ -9,7 +9,7 @@
          v-if="show"
          :hack="shouldShow"
          @click="overlayClicked"
-         :style="Object.assign({left: left + 'px'} ,overlayStyle)">
+         :style="overlayStyle">
     </div>
   </div>
 </template>
@@ -26,6 +26,8 @@
 
 <script>
   const animation = weex.requireModule('animation');
+  import Utils from '../utils';
+
   export default {
     props: {
       show: {
@@ -61,7 +63,8 @@
       overlayStyle () {
         return {
           opacity: this.hasAnimation ? 0 : 1,
-          backgroundColor: `rgba(0, 0, 0,${this.opacity})`
+          backgroundColor: `rgba(0, 0, 0,${this.opacity})`,
+          left: Utils.env.isWeb() ? this.left + 'px' : 0
         }
       },
       shouldShow () {


### PR DESCRIPTION
https://github.com/alibaba/weex-ui/issues/429
添加了:left属性，可以移动弹窗位置。