### PR TITLE
[!] wxc-overlay添加top,距顶部距离可配置

### DIFF
--- a/packages/wxc-overlay/README.md
+++ b/packages/wxc-overlay/README.md
@@ -51,6 +51,7 @@ More details can be found in [here](https://github.com/alibaba/weex-ui/blob/mast
 | show | `Boolean` |`Y`| `false` | whether to show  |
 | opacity | `Number` |`N`| `0.6` | opacity `0-1` |
 | left | `Number` |`N`| `0` | move left distance  |
+| top | `Number` |`N`| `0` | move top distance  |
 | has-animation | `Boolean` |`N`| `true` | whether to animate |
 | can-auto-close | `Boolean` |`N`| `true` | whether to can auto close  |
 | duration | `Number` | `300` |`N`| animation duration time |

--- a/packages/wxc-overlay/README_cn.md
+++ b/packages/wxc-overlay/README_cn.md
@@ -49,6 +49,7 @@
 |-------------|------------|--------|-----|
 | show | `Boolean` |`Y`| `false` | 是否开启  |
 | left | `Number` |`N`| `0` | 向左移动距离  |
+| top | `Number` |`N`| `0` | 向上移动距离  |
 | opacity | `Number` |`N`| `0.6` | 蒙层opacity度数0-1 |
 | has-animation | `Boolean` |`N`| `true` | 是否开启蒙层出现动画  |
 | can-auto-close | `Boolean` |`N`| `true` | 是否可以点击自动关闭  |

--- a/packages/wxc-overlay/index.vue
+++ b/packages/wxc-overlay/index.vue
@@ -18,7 +18,6 @@
   .wxc-overlay {
     width: 750px;
     position: fixed;
-    top: 0;
     bottom: 0;
     right: 0;
   }
@@ -33,6 +32,10 @@
       show: {
         type: Boolean,
         default: true
+      },
+      top: {
+        type: Number,
+        default: 0
       },
       left: {
         default: Number,
@@ -64,7 +67,8 @@
         return {
           opacity: this.hasAnimation ? 0 : 1,
           backgroundColor: `rgba(0, 0, 0,${this.opacity})`,
-          left: Utils.env.isWeb() ? this.left + 'px' : 0
+          left: Utils.env.isWeb() ? this.left + 'px' : 0,
+          top: this.top
         }
       },
       shouldShow () {


### PR DESCRIPTION
某些情景下需要 wxc-overlay 不覆盖 wxc-minibar 的情况；
开发者在使用wxc-overlay、wxc-mask、wxc-popup时都可自由设置是否覆盖wxc-minibar;